### PR TITLE
Add native REAPER track gain reduction metering (ext_gr_meter)

### DIFF
--- a/jsfx/JClones_AC1.jsfx
+++ b/jsfx/JClones_AC1.jsfx
@@ -44,6 +44,8 @@ slider9:0<0,1,1{AC1,AC101>Mode
 
 @init
 
+ext_gr_meter = 0.0;
+
 function DB_TO_K(x)
 (
   10 ^ (x / 20)
@@ -74,6 +76,8 @@ function AChannel_processSample(x, x_level) local(filter_k, gr)
   (this.ac101_mode) ? (
     (x_level > 1.0) ? ( gr = 1.0 / (x_level + 0.00001) * (this.a + 0.25); );
   );
+
+  this.gr = gr;
 
   x * gr * this.output_gain;
 );
@@ -129,4 +133,6 @@ level_2 = abs(spl1);
 
 spl0 = left.AChannel_processSample(spl0, level_1);
 spl1 = right.AChannel_processSample(spl1, level_2);
+
+ext_gr_meter = 20 * log10(min(left.gr, right.gr));
 

--- a/jsfx/JClones_CA2A.jsfx
+++ b/jsfx/JClones_CA2A.jsfx
@@ -36,6 +36,8 @@ slider5:1<0,1,1{Classic,Fast}>Opto Cell
 
 @init
 
+ext_gr_meter = 0.0;
+
 function DB_TO_K(x)
 (
   10 ^ (x / 20)
@@ -374,6 +376,8 @@ function LACompressor_processSampleStereo(x1, x2) local(sc_left, sc_right,
   v5 = pow(this.gr_const_D / (this.gr_const_D + v4), !this.is_limit ? 0.79 : 0.94);
 
   gain_reduction = this.LACompressor_getGainReduction(v5);
+  
+  this.gr = gain_reduction;
 
   // input saturation
 
@@ -499,6 +503,8 @@ comp.LACompressor_setOptoCell(!opto_cell);
 @sample
 
 comp.LACompressor_processSampleStereo(spl0, spl1);
+
+ext_gr_meter = 20 * log10(comp.gr);
 
 spl0 = comp.y1;
 spl1 = comp.y2;

--- a/jsfx/JClones_CL1B.jsfx
+++ b/jsfx/JClones_CL1B.jsfx
@@ -37,6 +37,8 @@ slider6:0<-24,24,0.1>Output Gain, dB
 
 @init
 
+ext_gr_meter = 0.0;
+
 function DB_TO_K(x)
 (
   10 ^ (x / 20)
@@ -285,6 +287,8 @@ function CLCompressor_processSampleStereo(x1, x2)
   // output
   y1 = x1 * this.T10 * this.T11 * gain_reduction * 33.768673;
   y2 = x2 * this.T10 * this.T11 * gain_reduction * 33.768673;
+  
+  this.gr = gain_reduction;
 
   // post_eq
   this.post_eq_s1 += (y1 - this.post_eq_s1) * this.post_eq_k;
@@ -681,6 +685,8 @@ effect.CLCompressor_setParameters(
 @sample
 
 effect.CLCompressor_processSampleStereo(spl0, spl1);
+
+ext_gr_meter = 20 * log10(effect.gr);
 
 spl0 = effect.y1;
 spl1 = effect.y2;

--- a/jsfx/JClones_Classic_Master_Limiter.jsfx
+++ b/jsfx/JClones_Classic_Master_Limiter.jsfx
@@ -16,6 +16,8 @@ slider1:-5<-20,0,0.1>Threshold, dB
 
 @init
 
+ext_gr_meter = 0.0;
+
 // for allocator
 function allocate(size) local(result)
 (
@@ -170,7 +172,8 @@ function ClassicLimiter_processSample(x) local(L, iGR_1, y1, y2, iGR_2, y3, iGR_
   this.iGR_X = min(this.iGR_X, this.iGR_B);
 
   // apply attack to GR, apply GR
-  y1 = x * (1.0 - this.attack.Filter1_processSample(this.iGR_X));
+  gr1 = (1.0 - this.attack.Filter1_processSample(this.iGR_X));
+  y1 = x * gr1;
 
   // pass#2
   L = abs(y1);
@@ -179,8 +182,10 @@ function ClassicLimiter_processSample(x) local(L, iGR_1, y1, y2, iGR_2, y3, iGR_
     iGR_2 = (1.0 - this.threshold_k / L);
 
     // apply GR^3 (T*3 with soft knee)
-    y2 = y1 * (1.0 - iGR_2 * iGR_2 * iGR_2);
+    gr2 = (1.0 - iGR_2 * iGR_2 * iGR_2);
+    y2 = y1 * gr2;
   ) : (
+    gr2 = 1.0;
     y2 = y1;
   );
 
@@ -208,7 +213,8 @@ function ClassicLimiter_processSample(x) local(L, iGR_1, y1, y2, iGR_2, y3, iGR_
   this.iGR_E += (this.iGR_D - this.iGR_E) * this.kE;   // secondary release
   this.iGR_E = min(this.iGR_E, this.iGR_D);
 
-  y4 = y3 * (1.0 - this.iGR_E);
+  gr3 = (1.0 - this.iGR_E);
+  y4 = y3 * gr3;
 
   // pass#4
   L = abs(y4) + ONE_E_20;
@@ -218,7 +224,9 @@ function ClassicLimiter_processSample(x) local(L, iGR_1, y1, y2, iGR_2, y3, iGR_
   iGR_4 = max(iGR_4, ONE_E_20);
 
   // apply gain reduction and master gain
-  y4 * (1.0 - iGR_4) * this.master_gain;
+  gr4 = 1.0 - iGR_4;
+  this.gr = gr1 * gr2 * gr3 * gr4;
+  y4 * gr4 * this.master_gain;
 );
 
 // continue @init:
@@ -254,4 +262,6 @@ right.ClassicLimiter_setThreshold(threshold_k);
 
 spl0 = left.ClassicLimiter_processSample(spl0);
 spl1 = right.ClassicLimiter_processSample(spl1);
+
+ext_gr_meter = 20 * log10(min(left.gr, right.gr));
 

--- a/jsfx/JClones_Hyrax.jsfx
+++ b/jsfx/JClones_Hyrax.jsfx
@@ -19,6 +19,8 @@ slider2:-1<-18,0,0.1>Threshold, dB
 
 @init
 
+ext_gr_meter = 0.0;
+
 // for allocator
 function allocate(size) local(result)
 (
@@ -476,6 +478,8 @@ function Limiter_processSampleStereo(x_left, x_right) local(level_x, flip_gr, sl
   this.y_right = this.x_right_compensation.DelayLine_pushSample(x_right);
 
   total_flip_gr = max(max(attack, release), flip_gr);
+  
+  this.gr = 1.0 - total_flip_gr;
 
   this.y_left *= (1.0 - total_flip_gr);
   this.y_right *= (1.0 - total_flip_gr);
@@ -515,6 +519,8 @@ limiter.Limiter_setThreshold(DB_TO_K(threshold_dB));
 @sample
 
 limiter.Limiter_processSampleStereo(spl0 * input_gain_k, spl1 * input_gain_k);
+
+ext_gr_meter = 20 * log10(limiter.gr);
 
 spl0 = limiter.y_left;
 spl1 = limiter.y_right;

--- a/jsfx/JClones_L2.jsfx
+++ b/jsfx/JClones_L2.jsfx
@@ -88,6 +88,8 @@ slider7:2<0,3,1{None,Moderate,Normal,Ultra}>Shaping
 
 @init
 
+ext_gr_meter = 0.0;
+
 // for allocator
 function allocate(size) local(result)
 (
@@ -796,6 +798,8 @@ min_gr = delay_min_gr.DelayLineMin_getMin();
 // smooth GR by attack
 output_gr = moving_average_gr_1.MovingAverageFilter_pushSample(output_gr);
 output_gr = moving_average_gr_2.MovingAverageFilter_pushSample(output_gr);
+
+ext_gr_meter = 20 * log10(output_gr);
 
 // delay input
 input_left = delay_line_left.DelayLine_pushSample(spl0);

--- a/jsfx/JClones_LMC1.jsfx
+++ b/jsfx/JClones_LMC1.jsfx
@@ -25,6 +25,8 @@ slider4:1<0,1,1{Off,On}>Box Tone
 
 @init
 
+ext_gr_meter = 0.0;
+
 function DB_TO_K(x)
 (
   10 ^ (x / 20)
@@ -152,4 +154,6 @@ right.LMC_setThreshold(threshold_dB, use_box_tone);
 
 spl0 = left.LMC_processSample(spl0 * input_gain_k) * output_gain_k;
 spl1 = right.LMC_processSample(spl1 * input_gain_k) * output_gain_k;
+
+ext_gr_meter = 20 * log10(min(left.feedback_gr, right.feedback_gr));
 

--- a/jsfx/JClones_O3_Maximizer.jsfx
+++ b/jsfx/JClones_O3_Maximizer.jsfx
@@ -25,6 +25,8 @@ slider4:0<0,1,1{Off,On}>Prevent ISP
 
 @init
 
+ext_gr_meter = 0.0;
+
 // for allocator
 function allocate(size) local(result)
 (
@@ -431,6 +433,7 @@ function Ozone3Limiter_processSampleStereo(input_left, input_right) local(input_
 
   // 8. apply gain reduction
   output_gr = DB_TO_K(-final_gr_dB);
+  this.gr = output_gr;
 
   this.y_left = this.delay_left.DelayLine_pushSample(input_left) * output_gr;
   this.y_right = this.delay_right.DelayLine_pushSample(input_right) * output_gr;
@@ -567,6 +570,8 @@ limiter.Ozone3Limiter_setPreventISP(param_prevent_isp);
 @sample
 
 limiter.Ozone3Limiter_processSampleStereo(spl0 * param_input_gain_k, spl1 * param_input_gain_k);
+
+ext_gr_meter = 20 * log10(limiter.gr);
 
 spl0 = limiter.y_left * param_output_gain_k;
 spl1 = limiter.y_right * param_output_gain_k;

--- a/jsfx/JClones_RS124.jsfx
+++ b/jsfx/JClones_RS124.jsfx
@@ -37,6 +37,8 @@ slider6:1<0,1,1{Off,On}>Box Tone
 
 @init
 
+ext_gr_meter = 0.0;
+
 function DB_TO_K(x)
 (
  10 ^ (x / 20)
@@ -801,5 +803,8 @@ right.RS124Compressor_setParameters(slider1, input_gain_org, slider3, slider4, s
 
 spl0 = left.RS124Compressor_processSample(spl0);
 spl1 = right.RS124Compressor_processSample(spl1);
+
+ext_gr_meter = 20 * log10(min(left.feedback_gr, right.feedback_gr));
+
 
 

--- a/jsfx/JClones_VBL.jsfx
+++ b/jsfx/JClones_VBL.jsfx
@@ -43,6 +43,8 @@ slider10:1<0,1,1{Off,On}>Trafo
 
 @init
 
+ext_gr_meter = 0.0;
+
 function DB_TO_K(x)
 (
   10 ^ (x / 20)
@@ -722,4 +724,6 @@ spl1 = input1 * dry_mix_k + (1.0 - dry_mix_k) * spl1 * output_gain_k;
 // "trafo" (post dry mix because of phase rotation)
 spl0 = left.sat.VblSaturator_applyTrafo(spl0, spl1);
 spl1 = right.sat.VblSaturator_applyTrafo(spl1, spl0);
+
+ext_gr_meter = 20 * log10(min(left.sat.feedback_gr, right.sat.feedback_gr));
 


### PR DESCRIPTION
Solves #1

## Overview
This PR adds support for REAPER's native gain reduction reporting to all core dynamic processors within the repository.
By populating the `ext_gr_meter` variable in the `@sample` stage, REAPER can now accurately display the instantaneous gain reduction of these plugins directly on the mixer and TCP track meters. This brings these plugins in line with modern metering workflows in REAPER.
## Changes Made
Added continuous `ext_gr_meter` reporting to the following explicitly pure dynamic processors:
* `JClones_CA2A.jsfx`
* `JClones_CL1B.jsfx`
* `JClones_Classic_Master_Limiter.jsfx` (Combines suppression from all 4 filter passes)
* `JClones_Hyrax.jsfx`
* `JClones_L2.jsfx`
* `JClones_LMC1.jsfx`
* `JClones_O3_Maximizer.jsfx`
* `JClones_RS124.jsfx`
* `JClones_VBL.jsfx`